### PR TITLE
Updated PX4-User Guide url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Main features:
 ## Getting Started
 
 For detailed instructions on how to get started read through 
-[PX4-Guide](https://docs.px4.io/main/en/tutorials/video_streaming_wifi_broadcast.html)
+[PX4-Guide](https://docs.px4.io/main/en/companion_computer/video_streaming_wfb_ng_wifi.html)
 and follow the [Setup HowTo](https://github.com/svpcom/wfb-ng/wiki/Setup-HOWTO)
 
 ### Quick start using Raspberry Pi


### PR DESCRIPTION
The current link to PX4 guide doesn't exist or has been moved.
Updated the new link in the Readme.md

Please review the changes and merge.