### PR TITLE
Fix for Jetson Orin Jammy(22.04) python local path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ all: all_bin gs.key test
 
 $(ENV):
 	virtualenv --python=$(PYTHON) $(ENV)
-	$(ENV)/bin/pip install --upgrade pip setuptools stdeb
+	[ -f $(ENV)/local/bin/pip ] && $(ENV)/local/bin/pip install --upgrade pip setuptools stdeb \
+                                || $(ENV)/bin/pip install --upgrade pip setuptools stdeb
 
 all_bin: wfb_rx wfb_tx wfb_keygen
 
@@ -47,7 +48,8 @@ rpm:  all_bin $(ENV)
 
 deb:  all_bin $(ENV)
 	rm -rf deb_dist
-	$(ENV)/bin/python ./setup.py --command-packages=stdeb.command bdist_deb
+	[ -f $(ENV)/local/bin/python ] && $(ENV)/local/bin/python ./setup.py --command-packages=stdeb.command bdist_deb \
+                                   || $(ENV)/bin/python ./setup.py --command-packages=stdeb.command bdist_deb
 	rm -rf wfb_ng.egg-info/ wfb-ng-$(VERSION).tar.gz
 
 bdist: all_bin


### PR DESCRIPTION
[ [Jetson Orin] wfb-ng/env/bin/pip: No such file or directory #333 ](https://github.com/svpcom/wfb-ng/issues/333)

Drop https://github.com/svpcom/wfb-ng/pull/334  

@svpcom Please test env/bin python path if it can merge.

Currently, it has been test on Jetson Orin jammy(22.04), which has env/local/bin python path.