### PR TITLE
Pass LDFLAGS to wfb_tx_cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ wfb_keygen: src/keygen.o
 	$(CC) -o $@ $^ $(_LDFLAGS)
 
 wfb_tx_cmd: src/tx_cmd.o
-	$(CC) -o $@ $^
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 test: all_bin
 	PYTHONPATH=`pwd` trial3 wfb_ng.tests


### PR DESCRIPTION
Allows the build system to properly pass extra flags, e.g. GNU_HASH for openembedded