### PR TITLE
Noise reporting in MavLink

### DIFF
--- a/wfb_ng/proxy.py
+++ b/wfb_ng/proxy.py
@@ -84,7 +84,7 @@ class ProxyProtocol:
             self.agg_queue_timer = reactor.callLater(self.agg_timeout, self.flush_queue)
 
     # inject radio rssi info
-    def send_rssi(self, rssi, rx_errors, rx_fec, flags):
+    def send_rssi(self, rssi, noise, rx_errors, rx_fec, flags):
         pass
 
 
@@ -125,11 +125,11 @@ class MavlinkProxyProtocol(ProxyProtocol):
         else:
             self.radio_mav = None
 
-    def send_rssi(self, rssi, rx_errors, rx_fec, flags):
+    def send_rssi(self, rssi, noise, rx_errors, rx_fec, flags):
         # Send flags as remnoise, because txbuf value is used by PX4 to throttle bandwidth
         # use self.write to send mavlink message
         if self.radio_mav is not None:
-            self.radio_mav.radio_status_send(rssi, rssi, 100, 0, flags, rx_errors, rx_fec)
+            self.radio_mav.radio_status_send(rssi % 256, rssi % 256, 100, noise % 256, flags, rx_errors, rx_fec)
 
 
 class MavlinkUDPProxyProtocol(DatagramProtocol, MavlinkProxyProtocol):

--- a/wfb_ng/tests/test_proxy.py
+++ b/wfb_ng/tests/test_proxy.py
@@ -82,10 +82,10 @@ class UDPProxyTestCase(unittest.TestCase):
         yield df_sleep(0.1)
 
         try:
-            self.p1.send_rssi(1, 2, 3, 4)
+            self.p1.send_rssi(1, 2, 3, 4, 5)
             ts = time.time()
             _replies = yield p.df
-            _expected = [(b'\xfd\t\x00\x00\x00\x03\xf2m\x00\x00\x02\x00\x03\x00\x01\x01d\x00\x04\xa8\xad', addr)]
+            _expected = [(b'\xfd\t\x00\x00\x00\x03\xf2m\x00\x00\x03\x00\x04\x00\x01\x01d\x02\x05\xe1\xb1', addr)]
             self.assertLess(time.time() - ts, 1.0)
             self.assertEqual(_replies, _expected)
         finally:


### PR DESCRIPTION
I'm playing with endurance flights and it's very useful to not only have the absolute RSSI, but also noise/SNR values in the MavLink stream (and in the vehicle log accordingly). 

These changes seem to work (although I'm based on 24.08 so I did a bit of forwardporting). ~~I'm not totally sure about the test though since it doesn't seem to test for `RADIO_STATUS` message anyway?~~ nvm, CI showed what changed.  