### PR TITLE
Add configurable logger support

### DIFF
--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdarg>
+
+
+// Since this file is most likely to be used outside of the project (like, in Android),
+// using a namespace to avoid conflicts
+namespace wfb {
+enum class LogLevel {
+    ALWAYS,
+    ERROR,
+    WARNING,
+    INFO,
+    DEBUG
+};
+
+class Logger
+{
+public:
+    virtual ~Logger() = default;
+    virtual void logln(LogLevel level, const char* format, ...) = 0;
+};
+
+class StdErrLogger : public Logger
+{
+public:
+    void logln(LogLevel level, const char* format, ...) override {
+        const char* level_str = "";
+        switch (level) {
+            case LogLevel::DEBUG:
+            case LogLevel::INFO:
+                return;
+            case LogLevel::ALWAYS:
+                break;
+            case LogLevel::WARNING:
+                level_str = "WARNING: ";
+                break;
+            case LogLevel::ERROR:
+                level_str = "ERROR: ";
+                break;
+        }
+
+        char buffer[1024];
+        va_list args;
+        va_start(args, format);
+        int prefix_len = snprintf(buffer, sizeof(buffer), "%s", level_str);
+        if (prefix_len < 0)
+            return;
+
+        int message_len = vsnprintf(buffer + prefix_len, sizeof(buffer) - prefix_len - 2, format, args);
+        if (message_len < 0)
+            return;
+
+        va_end(args);
+
+        buffer[prefix_len + message_len] = '\n';
+        buffer[prefix_len + message_len + 1] = '\0';
+    }
+};
+} // namespace wfb

--- a/src/rx.hpp
+++ b/src/rx.hpp
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <stdexcept>
 
+#include "logger.hpp"
 #include "wifibroadcast.hpp"
 
 
@@ -52,7 +53,8 @@ public:
 class Forwarder : public BaseAggregator
 {
 public:
-    Forwarder(const std::string &client_addr, int client_port);
+    Forwarder(const std::string &client_addr, int client_port,
+              std::shared_ptr<wfb::Logger> logger = std::make_shared<wfb::StdErrLogger>());
     virtual ~Forwarder();
     virtual void process_packet(const uint8_t *buf, size_t size, uint8_t wlan_idx, const uint8_t *antenna,
                                 const int8_t *rssi, const int8_t *noise, uint16_t freq, uint8_t mcs_index,
@@ -61,6 +63,7 @@ public:
 private:
     int sockfd;
     struct sockaddr_in saddr;
+    std::shared_ptr<wfb::Logger> logger;
 };
 
 
@@ -158,7 +161,8 @@ typedef std::unordered_map<rxAntennaKey, rxAntennaItem> rx_antenna_stat_t;
 class Aggregator : public BaseAggregator
 {
 public:
-    Aggregator(const std::string &client_addr, int client_port, const std::string &keypair, uint64_t epoch, uint32_t channel_id);
+    Aggregator(const std::string &client_addr, int client_port, const std::string &keypair, uint64_t epoch, uint32_t channel_id,
+               std::shared_ptr<wfb::Logger> logger = std::make_shared<wfb::StdErrLogger>());
     virtual ~Aggregator();
     virtual void process_packet(const uint8_t *buf, size_t size, uint8_t wlan_idx, const uint8_t *antenna,
                                 const int8_t *rssi, const int8_t *noise, uint16_t freq, uint8_t mcs_index,
@@ -220,6 +224,7 @@ private:
     uint64_t last_known_block;  //id of last known block
     uint64_t epoch; // current epoch
     const uint32_t channel_id; // (link_id << 8) + port_number
+    std::shared_ptr<wfb::Logger> logger;
 
     // rx->tx keypair
     uint8_t rx_secretkey[crypto_box_SECRETKEYBYTES];
@@ -230,7 +235,8 @@ private:
 class Receiver
 {
 public:
-    Receiver(const char* wlan, int wlan_idx, uint32_t channel_id, BaseAggregator* agg, int rcv_buf_size);
+    Receiver(const char* wlan, int wlan_idx, uint32_t channel_id, BaseAggregator* agg, int rcv_buf_size,
+             std::shared_ptr<wfb::Logger> logger = std::make_shared<wfb::StdErrLogger>());
     ~Receiver();
     void loop_iter(void);
     int getfd(void){ return fd; }
@@ -239,4 +245,5 @@ private:
     BaseAggregator *agg;
     int fd;
     pcap_t *ppcap;
+    std::shared_ptr<wfb::Logger> logger;
 };


### PR DESCRIPTION
The new logger interface provides a single function, `logln`, which can be implemented by the users of the API.
The interface has a default implementation, `StdErrLogger`, which logs the data to `stderr` if the level is higher than `LogLevel::INFO`. `LogLevel::ALWAYS` is always logged without a prefix to match the existing behavior.