### PR TITLE
add bind mode

### DIFF
--- a/src/rx.hpp
+++ b/src/rx.hpp
@@ -222,6 +222,7 @@ private:
     const uint32_t channel_id; // (link_id << 8) + port_number
 
     // rx->tx keypair
+    std::string keyfile;
     uint8_t rx_secretkey[crypto_box_SECRETKEYBYTES];
     uint8_t tx_publickey[crypto_box_PUBLICKEYBYTES];
     uint8_t session_key[crypto_aead_chacha20poly1305_KEYBYTES];

--- a/src/tx.hpp
+++ b/src/tx.hpp
@@ -76,6 +76,7 @@ public:
     bool send_packet(const uint8_t *buf, size_t size, uint8_t flags);
     void send_session_key(void);
     void init_session(int k, int n);
+    void send_bind_key(const uint8_t *key, size_t key_size);
     void get_fec(int &k, int &n) { k = fec_k; n = fec_n; }
     virtual void select_output(int idx) = 0;
     virtual void dump_stats(uint64_t ts, uint32_t &injected_packets, uint32_t &dropped_packets, uint32_t &injected_bytes) = 0;

--- a/src/tx_cmd.h
+++ b/src/tx_cmd.h
@@ -4,6 +4,7 @@
 #define CMD_SET_RADIO 2
 #define CMD_GET_FEC   3
 #define CMD_GET_RADIO 4
+#define CMD_BIND_KEY  5
 
 typedef struct {
     uint32_t req_id;
@@ -25,6 +26,11 @@ typedef struct {
             bool vht_mode;
             uint8_t vht_nss;
         } __attribute__ ((packed)) cmd_set_radio;
+
+        struct
+        {
+            char keypair[1024];
+        } __attribute__ ((packed)) cmd_bind;        
     } __attribute__ ((packed)) u;
 } __attribute__ ((packed)) cmd_req_t;
 

--- a/src/wifibroadcast.hpp
+++ b/src/wifibroadcast.hpp
@@ -190,6 +190,7 @@ static const uint8_t ieee80211_header[] __attribute__((unused)) = {
 // packet types
 #define WFB_PACKET_DATA    0x1
 #define WFB_PACKET_SESSION 0x2
+#define WFB_PACKET_BIND_KEY 0x03
 
 // FEC types
 #define WFB_FEC_VDM_RS  0x1  //Reed-Solomon on Vandermonde matrix
@@ -257,6 +258,7 @@ typedef struct {
 #define MAX_FEC_PAYLOAD  (WIFI_MTU - sizeof(ieee80211_header) - sizeof(wblock_hdr_t) - crypto_aead_chacha20poly1305_ABYTES)
 #define MAX_FORWARDER_PACKET_SIZE (WIFI_MTU - sizeof(ieee80211_header))
 #define MAX_SESSION_PACKET_SIZE (WIFI_MTU - sizeof(ieee80211_header))
+#define MAX_BIND_KEY_SIZE (WIFI_MTU - sizeof(ieee80211_header))
 #define MIN_DISTRIBUTION_PACKET_SIZE (sizeof(uint32_t) + sizeof(radiotap_header_ht) + sizeof(ieee80211_header))   // ht hdr < vht hdr
 #define MAX_DISTRIBUTION_PACKET_SIZE (sizeof(uint32_t) + sizeof(radiotap_header_vht) + WIFI_MTU)
 #define MAX_PCAP_PACKET_SIZE (WIFI_MTU + 256)  // radiotap header is variable but 8812au/eu has max rtap buffer size 256


### PR DESCRIPTION
This MR adds a bind mode to wfb_rx, wfb_tx, and wfb_tx_cmd.

The idea is to simplify the exchange of key material. A drone can have a bind button or use "three plug detection" to enable bind mode. In this mode, it accepts an unencrypted bind packet from the GS.

To enable bind mode on the drone side, wfb_rx needs to receive a SIGUSR1 signal. On the GS side, wfb_tx and wfb_tx_cmd have a new bind command, which optionally takes the key file name as an argument to send.

Caveat: Currently, only the receiving instance of wfb_rx updates its keys without requiring a restart. Other instances may still be using the old keys.