### PR TITLE
Added the option to set WiFi channel by providing frequency in MHz

### DIFF
--- a/wfb_ng/server.py
+++ b/wfb_ng/server.py
@@ -113,7 +113,7 @@ def init_wlans(max_bw, wlans):
                 channel = settings.common.wifi_channel
 
             if channel>2000:
-                yield call_and_check_rc('iw', 'dev', wlan, 'set', 'freq', str(channel)+ 'M', ht_mode) #set by frequency number in Mhz
+                yield call_and_check_rc('iw', 'dev', wlan, 'set', 'freq', str(channel), ht_mode) #set by frequency number in Mhz
             else:
                 yield call_and_check_rc('iw', 'dev', wlan, 'set', 'channel', str(channel), ht_mode)
 

--- a/wfb_ng/server.py
+++ b/wfb_ng/server.py
@@ -112,7 +112,10 @@ def init_wlans(max_bw, wlans):
             else:
                 channel = settings.common.wifi_channel
 
-            yield call_and_check_rc('iw', 'dev', wlan, 'set', 'channel', str(channel), ht_mode)
+            if channel>2000:
+                yield call_and_check_rc('iw', 'dev', wlan, 'set', 'freq', str(channel)+ 'M', ht_mode) #set by frequency number in Mhz
+            else:
+                yield call_and_check_rc('iw', 'dev', wlan, 'set', 'channel', str(channel), ht_mode)
 
             txpower = settings.common.wifi_txpower
 


### PR DESCRIPTION
Some WiFi adapters allow frequencies outside of the official channels (Atheros)
The addition will allow the user can to set the frequency in Mhz instead the channel number, like this
```
[common]
wifi_channel = 2347     # 161 -- radio channel @5825 MHz, range: 5815–5835 MHz, width 20MHz
                       # 1 -- radio channel @2412 Mhz,

```
this will result in `# iw dev wlx00127b216fa7 set freq 2347 HT20` command issued to the driver and will set 2347Mhz frequency.

