### PR TITLE
Add support for OTA updates for client/server apps that use WFB

### DIFF
--- a/src/rx.cpp
+++ b/src/rx.cpp
@@ -673,6 +673,16 @@ void Aggregator::process_packet(const uint8_t *buf, size_t size, uint8_t wlan_id
 
         return;
 
+    case WFB_PACKET_OTA:
+        if(size < sizeof(ota_hdr_t))
+        {
+            WFB_ERR("Short packet (invalid OTA packet)\n");
+            return;
+        }
+        if (-1 != sockfd)
+            sendto(sockfd, buf, size, MSG_DONTWAIT, (sockaddr*)&saddr, sizeof(saddr));
+        return;
+
     default:
         WFB_ERR("Unknown packet type 0x%x\n", buf[0]);
         count_p_bad += 1;

--- a/src/tx.cpp
+++ b/src/tx.cpp
@@ -573,6 +573,12 @@ bool Transmitter::send_packet(const uint8_t *buf, size_t size, uint8_t flags)
 {
     assert(size <= MAX_PAYLOAD_SIZE);
 
+    if (buf[0] == WFB_PACKET_OTA)
+    {
+        inject_packet(buf, size);
+        return true;
+    }
+
     // FEC-only packets are only for closing already opened blocks
     if (fragment_idx == 0 && (flags & WFB_PACKET_FEC_ONLY))
     {

--- a/src/wifibroadcast.hpp
+++ b/src/wifibroadcast.hpp
@@ -179,7 +179,14 @@ static const uint8_t ieee80211_header[] __attribute__((unused)) = {
                             fec_type, fec_k, fec_n,  #
                             session_key,             #
                             optional TLV list }      # -- encrypted and signed using rx and tx keys
- */
+
+     3. OTA packet:
+          ota_hdr   { message type, byte:
+                              none, query firmware version, firmware version response, send OTA package segment, ACK OTA package segment, send OTA status;
+                      message data length: two bytes;
+                      message crc: 4 bytes }
+          ota_data: 0...N bytes, depending on message type; 
+*/
 
 // data nonce:  56bit block_idx + 8bit fragment_idx
 // session nonce: crypto_box_NONCEBYTES of random bytes
@@ -190,6 +197,7 @@ static const uint8_t ieee80211_header[] __attribute__((unused)) = {
 // packet types
 #define WFB_PACKET_DATA    0x1
 #define WFB_PACKET_SESSION 0x2
+#define WFB_PACKET_OTA     0x3
 
 // FEC types
 #define WFB_FEC_VDM_RS  0x1  //Reed-Solomon on Vandermonde matrix
@@ -251,6 +259,15 @@ typedef struct {
     uint8_t flags;
     uint16_t packet_size; // big endian
 }  __attribute__ ((packed)) wpacket_hdr_t;
+
+
+// OTA packet
+
+typedef struct {
+    uint8_t message_type;
+    uint16_t data_length;
+    uint32_t crc;
+}  __attribute__ ((packed)) ota_hdr_t;
 
 
 #define MAX_PAYLOAD_SIZE (WIFI_MTU - sizeof(ieee80211_header) - sizeof(wblock_hdr_t) - crypto_aead_chacha20poly1305_ABYTES - sizeof(wpacket_hdr_t))


### PR DESCRIPTION
Add support to allow client/server apps that use WFB protocol, and the ones who don't, to initiate and do an OTA update of the client device over the WFB radio link. The actual OTA protocol and logic is handled by the client/server apps, not by the WFB stack. WFB just provides a way to exchange OTA messages, for clients and clients where one end might not be using WFB natively. The WFB protocol update is transparent for the (existing/future) clients. No change is required in existing WFB clients.